### PR TITLE
Surround ERTS_INCLUDE_DIR, ERL_INTERFACE_INCLUDE_DIR, ERL_INTERFACE_LIB_DIR with double quote char in order to be able support path with space char

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -31,10 +31,10 @@ else ifeq ($(UNAME_SYS), Linux)
 	CXXFLAGS ?= -O3 -finline-functions -Wall
 endif
 
-CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
-CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CFLAGS += -fPIC -I "$(ERTS_INCLUDE_DIR)" -I "$(ERL_INTERFACE_INCLUDE_DIR)"
+CXXFLAGS += -fPIC -I "$(ERTS_INCLUDE_DIR)" -I "$(ERL_INTERFACE_INCLUDE_DIR)"
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+LDLIBS += -L "$(ERL_INTERFACE_LIB_DIR)" -lerl_interface -lei
 LDFLAGS += -shared
 
 # Verbosity.


### PR DESCRIPTION
Hi, 

I get error:
```
Oka-Prinarjaya:okadaserve okaprinarjaya$ rebar3 compile
===> Fetching rebar3_run v0.2.0
===> Version cached at /Users/okaprinarjaya/.cache/rebar3/hex/hexpm/packages/rebar3_run-0.2.0.tar is up to date, reusing it
===> Compiling rebar3_run
cc -O3 -std=c99 -arch x86_64 -finline-functions -Wall -Wmissing-prototypes -fPIC -I /Users/okaprinarjaya/Library/Application Support/ErlangInstaller/21.2/erts-10.2/include/ -I /Users/okaprinarjaya/Library/Application Support/ErlangInstaller/21.2/lib/erl_interface-3.10.4/include  -c -o /Users/okaprinarjaya/Oprek/Erlang-Oprek-Dua/okadaserve/_build/default/plugins/rebar3_run/c_src/rebar3_run.o /Users/okaprinarjaya/Oprek/Erlang-Oprek-Dua/okadaserve/_build/default/plugins/rebar3_run/c_src/rebar3_run.c
clang: error: no such file or directory: 'Support/ErlangInstaller/21.2/erts-10.2/include/'
clang: error: no such file or directory: 'Support/ErlangInstaller/21.2/lib/erl_interface-3.10.4/include'
make: *** [/Users/okaprinarjaya/Oprek/Erlang-Oprek-Dua/okadaserve/_build/default/plugins/rebar3_run/c_src/rebar3_run.o] Error 1
===> Hook for compile failed!

===> Plugin rebar3_run not available. It will not be used.
```
It turns out the problem is linker cannot read path name with space char.

```
clang: error: no such file or directory: 'Support/ErlangInstaller/21.2/erts-10.2/include/'
clang: error: no such file or directory: 'Support/ErlangInstaller/21.2/lib/erl_interface-3.10.4/include'
```
My full path of erlang is `/Users/okaprinarjaya/Library/Application Support/ErlangInstaller/`. 
It fixed by adding double quote char by surround it in `ERTS_INCLUDE_DIR`, `ERL_INTERFACE_INCLUDE_DIR`, `ERL_INTERFACE_LIB_DIR` variables.

